### PR TITLE
This is a better way of defining args. Trust me...

### DIFF
--- a/coding-guides/a-basic-command-handler.md
+++ b/coding-guides/a-basic-command-handler.md
@@ -33,8 +33,8 @@ client.on("message", message => {
   if(message.content.indexOf(config.prefix) !== 0) return;
 
   // This is the best way to define args. Trust me.
-  const args = message.content.split(/\s+/g);
-  const command = args.shift().slice(config.prefix.length).toLowerCase();
+  const args = message.content.slice(config.prefix.length).trim().split(/\s+/g);
+  const command = args.shift().toLowerCase();
 
   // The list of if/else is replaced with those simple 2 lines:
   try {


### PR DESCRIPTION
if config.prefix is `ok google,` the original code would have split `ok` as the command and prefix, and tried to slice off 10 chars off that as the command and prefix combo. Additionally, it allows if you were to define the prefix as `<@123456789101112>` that both that mention and mention + space would work as a prefix. Meaning that in the original example `ok google,` and `ok google, ` would both work.