### PR TITLE
Fix where links redirect to 404 Github

### DIFF
--- a/coding-guides/using-audit-logs.md
+++ b/coding-guides/using-audit-logs.md
@@ -2,7 +2,7 @@
 
 From time to time, users in "An Idiot's Guide Official Server" need to reference audit logs for whatever reason, let it be viewing them for certain actions to adding things into the audit logs. This guide will explain everything about audit logs and how to use them.
 
-The first thing that you will need is a working Discord Bot. If you do not have one, please visit [Your First Bot](https://github.com/AnIdiotsGuide/discordjs-bot-guide/tree/55f4f549d165c6cafcc7e865ac6a98cf645fc6d6/coding-guides/getting-started/your-basic-bot.md) to get started. Now, some things to take note of. This guide is using discord.js@11.3.2. The bot will need some permissions. The main permission the bot will need is `'VIEW_AUDIT_LOGS'`. This permission allows the bot to view the audit logs.
+The first thing that you will need is a working Discord Bot. If you do not have one, please visit [Your First Bot](../getting-started/getting-started-your-basic-bot.md) to get started. Now, some things to take note of. This guide is using discord.js@11.3.2. The bot will need some permissions. The main permission the bot will need is `'VIEW_AUDIT_LOGS'`. This permission allows the bot to view the audit logs.
 
 Now that the permission has been established. Lets get started!
 

--- a/discord-webhooks/discord-webhooks-part-1.md
+++ b/discord-webhooks/discord-webhooks-part-1.md
@@ -101,5 +101,5 @@ Alright, now let's throw that together with our bot code and issue the command!
 
 Wooo! we did it!
 
-Now we can create webhooks on the fly via our bot code, but in the next [_chapter_](https://github.com/AnIdiotsGuide/discordjs-bot-guide/tree/6d360a9eb88ca7eab83f6534bc0e042809aec1d2/coding-guides/discord-webhooks-part-2.md) we'll see what we can do with them!
+Now we can create webhooks on the fly via our bot code, but in the next [_chapter_](discord-webhooks-part-2.md) we'll see what we can do with them!
 

--- a/discord-webhooks/discord-webhooks-part-2.md
+++ b/discord-webhooks/discord-webhooks-part-2.md
@@ -1,6 +1,6 @@
 # Discord Webhooks \(Part 2\)
 
-In the [last chapter](https://github.com/AnIdiotsGuide/discordjs-bot-guide/tree/6d360a9eb88ca7eab83f6534bc0e042809aec1d2/coding-guides/discord-webhooks-part1.md) we covered how to create the webhooks via code, which to be honest isn't very useful, in this chapter we will continue where we left off and we will actually use the webhooks we create in some bot code.
+In the [last chapter](discord-webhooks-part1.md) we covered how to create the webhooks via code, which to be honest isn't very useful, in this chapter we will continue where we left off and we will actually use the webhooks we create in some bot code.
 
 Now, one way we could use this, is to grab mentions... For some reason people think it's acceptable to mention me then shortly afterwards remove the mention if I don't respond within X seconds or minutes.
 

--- a/discord-webhooks/discord-webhooks-part-3.md
+++ b/discord-webhooks/discord-webhooks-part-3.md
@@ -26,7 +26,7 @@ Now there's not much we can do with third party services in regards to the stand
 
 ## ShareX
 
-Now, download and install [ShareX](https://getsharex.com/) and open up the program and click the drop down menu for `Destinations` and click [Destination Settings](https://github.com/AnIdiotsGuide/discordjs-bot-guide/tree/6d360a9eb88ca7eab83f6534bc0e042809aec1d2/assets/webhooks/wh10.png) then scroll down to the bottom for [Custom Uploaders](https://github.com/AnIdiotsGuide/discordjs-bot-guide/tree/6d360a9eb88ca7eab83f6534bc0e042809aec1d2/assets/webhooks/wh11.png) and click it.
+Now, download and install [ShareX](https://getsharex.com/) and open up the program and click the drop down menu for `Destinations` and click [Destination Settings](../.gitbook/assets/webhooks/wh10.png) then scroll down to the bottom for [Custom Uploaders](.../.gitbook/assets/webhooks/wh11.png) and click it.
 
 In the text field just under "Uploaders" put in `Discord`.
 

--- a/getting-started/getting-started-linux-tl-dr.md
+++ b/getting-started/getting-started-linux-tl-dr.md
@@ -1,6 +1,6 @@
 # Getting Started - Linux TL;DR
 
-> **This is the TL;DR version for Linux**. If you wish for a long version with more explanations, please see [this guide](https://github.com/AnIdiotsGuide/discordjs-bot-guide/tree/6d360a9eb88ca7eab83f6534bc0e042809aec1d2/getting-started/the-long-version.html)
+> **This is the TL;DR version for Linux**. If you wish for a long version with more explanations, please see [this guide](getting-started-long-version.md)
 
 ## Create App and Bot Account
 

--- a/getting-started/getting-started-long-version.md
+++ b/getting-started/getting-started-long-version.md
@@ -2,7 +2,7 @@
 
 So, you want to write a bot and you know some JavaScript, or maybe even node.js. You want to do cool things like a music bot, tag commands, random image searches, the whole shebang. Well you're at the right place!
 
-> **This is the long version** with a whole lot of useless blabbering text, jokes, and explanations. TL;DR \(short\) versions: [Windows](https://github.com/AnIdiotsGuide/discordjs-bot-guide/tree/6d360a9eb88ca7eab83f6534bc0e042809aec1d2/getting-started/windows-tldr.html) , [Linux](https://github.com/AnIdiotsGuide/discordjs-bot-guide/tree/6d360a9eb88ca7eab83f6534bc0e042809aec1d2/getting-started/linux-tldr.html)
+> **This is the long version** with a whole lot of useless blabbering text, jokes, and explanations. TL;DR \(short\) versions: [Windows](getting-started-windows-tl-dr.md) , [Linux](getting-started-linux-tl-dr.md)
 
 This tutorial will get you through the first steps of creating a bot, configuring it, making it run, and adding a couple of commands to it.
 

--- a/getting-started/getting-started-windows-tl-dr.md
+++ b/getting-started/getting-started-windows-tl-dr.md
@@ -1,6 +1,6 @@
 # Getting Started - Windows TL;DR
 
-> **This is the TL;DR version for Windows**. If you wish for a long version with more explanations, please see [this guide](https://github.com/AnIdiotsGuide/discordjs-bot-guide/tree/6d360a9eb88ca7eab83f6534bc0e042809aec1d2/getting-started/the-long-version.html)
+> **This is the TL;DR version for Windows**. If you wish for a long version with more explanations, please see [this guide](getting-started-long-version.md)
 
 ## Create App and Bot Account
 

--- a/other-guides/docker-part-1-setup-and-dockerfile.md
+++ b/other-guides/docker-part-1-setup-and-dockerfile.md
@@ -24,7 +24,7 @@ Discord.js Official Documentation is available [here](https://discord.js.org/#!/
 
 Don't forget, if you want to invite your bots to server, you'll need to get an invite link, you can use the Discord Permissions Calculator [here](https://finitereality.github.io/permissions/?v=0) to set up your permissions, and generate an invite link.
 
-Music in the video: Heavy Heart by Kevin MacLeod [incompetech.com](https://github.com/AnIdiotsGuide/discordjs-bot-guide/tree/6d360a9eb88ca7eab83f6534bc0e042809aec1d2/other-guides/incompetech.com) Licensed under Creative Commons: [By Attribution 3.0 License](http://creativecommons.org/licenses/by/3.0/)
+Music in the video: Heavy Heart by Kevin MacLeod [incompetech.com](https://incompetech.com) Licensed under Creative Commons: [By Attribution 3.0 License](http://creativecommons.org/licenses/by/3.0/)
 
 List of Atom addons and themes I use; Addons:
 

--- a/other-guides/docker-part-2-installing-running-and-more.md
+++ b/other-guides/docker-part-2-installing-running-and-more.md
@@ -24,7 +24,7 @@ Discord.js Official Documentation is available [here](https://discord.js.org/#!/
 
 Don't forget, if you want to invite your bots to server, you'll need to get an invite link, you can use the Discord Permissions Calculator [here](https://finitereality.github.io/permissions/?v=0) to set up your permissions, and generate an invite link.
 
-Music in the video: Heavy Heart by Kevin MacLeod [incompetech.com](https://github.com/AnIdiotsGuide/discordjs-bot-guide/tree/6d360a9eb88ca7eab83f6534bc0e042809aec1d2/other-guides/incompetech.com) Licensed under Creative Commons: [By Attribution 3.0 License](http://creativecommons.org/licenses/by/3.0/)
+Music in the video: Heavy Heart by Kevin MacLeod [incompetech.com](https://incompetech.com) Licensed under Creative Commons: [By Attribution 3.0 License](http://creativecommons.org/licenses/by/3.0/)
 
 List of Atom addons and themes I use; Addons:
 


### PR DESCRIPTION
- a0c5606cd5c7ff6fd4ee09626142c3c753a5e485 Links have been edited to be relative to their own directory instead of fixed to a single commit.
- dd9eef1727cef096334dbe8bdb6e9c56c9a8d550 and ead5b97ed1916e1ed93edf183ffe8fb3d81c00b3 Links now redirect outside of the guide.