### PR TITLE
Add "vckick" example to miscellaneous-examples.md

### DIFF
--- a/examples/miscellaneous-examples.md
+++ b/examples/miscellaneous-examples.md
@@ -221,6 +221,8 @@ if( swearWords.some(word => message.content.includes(word)) ) {
 
 Being able to kick a user or bot from a voice channel doesn't come within Discord sadly, and it's a great feature to have for general use, or if your developing a music bot or related that needs to be removed quickly. Luckily, there's a simple and fast way to do it, and it can be added easily.
 
+On a quick note, your message event **must be async**. This means that your `client.on('message', message ..` must include the `async` keyword, ie. `client.on('message', async message ..`, to avoid the using async in a non-async function error.
+
 ```javascript
 // Make sure the bot user has permissions to make channels and move members in the guild:
 if (!message.guild.me.hasPermission(['MANAGE_CHANNELS', 'MOVE_MEMBERS'])) return message.reply('Missing the required `Manage Channels` and `Move Members` permissions.');

--- a/examples/miscellaneous-examples.md
+++ b/examples/miscellaneous-examples.md
@@ -226,13 +226,13 @@ Being able to kick a user or bot from a voice channel doesn't come within Discor
 if (!message.guild.me.hasPermission(['MANAGE_CHANNELS', 'MOVE_MEMBERS'])) return message.reply('Missing the required `Manage Channels` and `Move Members` permissions.');
 
 // Get the mentioned user/bot and check if they're in a voice channel:
-const user = message.mentions.members.first();
-if (!user) return message.reply('You need to @mention a user/bot to kick from the voice channel.');
-if (!user.voiceChannel) return message.reply('That user/bot isn\'t in a voice channel.');
+const member = message.mentions.members.first();
+if (!member) return message.reply('You need to @mention a user/bot to kick from the voice channel.');
+if (!member.voiceChannel) return message.reply('That user/bot isn\'t in a voice channel.');
 
 // Now we make a temporary voice channel, move the user/bot into the channel, and delete it:
 const temp_channel = await message.guild.createChannel(user.id, 'voice');
-await user.setVoiceChannel(temp_channel);
+await member.setVoiceChannel(temp_channel);
 
 await temp_channel.delete();
 

--- a/examples/miscellaneous-examples.md
+++ b/examples/miscellaneous-examples.md
@@ -219,8 +219,6 @@ if( swearWords.some(word => message.content.includes(word)) ) {
 
 ### Kicking users (or bots) from a voice channel
 
-> Example by April#8035
-
 Being able to kick a user or bot from a voice channel doesn't come within Discord sadly, and it's a great feature to have for general use, or if your developing a music bot or related that needs to be removed quickly. Luckily, there's a simple and fast way to do it, and it can be added easily.
 
 *This example was made for discord.js-master, AKA v12, and it was designed with async/await usage in mind. It should be rather easy to backport to v11/stable however.*

--- a/examples/miscellaneous-examples.md
+++ b/examples/miscellaneous-examples.md
@@ -221,8 +221,6 @@ if( swearWords.some(word => message.content.includes(word)) ) {
 
 Being able to kick a user or bot from a voice channel doesn't come within Discord sadly, and it's a great feature to have for general use, or if your developing a music bot or related that needs to be removed quickly. Luckily, there's a simple and fast way to do it, and it can be added easily.
 
-*This example was made for discord.js-master, AKA v12, and it was designed with async/await usage in mind. It should be rather easy to backport to v11/stable however.*
-
 ```javascript
 // Make sure the bot user has permissions to make channels and move members in the guild:
 if (!message.guild.me.hasPermission('MANAGE_CHANNELS') || !message.guild.me.hasPermission('MOVE_MEMBERS')) return message.reply('missing the required `Manage Channels` and `Move Members` permissions.');
@@ -233,8 +231,9 @@ if (!user) return message.reply('you need to @mention a user/bot to kick from th
 if (!user.voiceChannel) return message.reply('that user/bot isn\'t in a voice channel.');
 
 // Now we make a temporary voice channel, move the user/bot into the channel, and delete it:
-const temp_channel = await message.guild.channels.create(user.user.id, { type: 'voice', userLimit: 1 });
+const temp_channel = await message.guild.createChannel(user.id, 'voice');
 await user.setVoiceChannel(temp_channel);
+
 await temp_channel.delete();
 
 // Finally, pass some user response to show it all worked out:

--- a/examples/miscellaneous-examples.md
+++ b/examples/miscellaneous-examples.md
@@ -219,11 +219,11 @@ if( swearWords.some(word => message.content.includes(word)) ) {
 
 ### Kicking users (or bots) from a voice channel
 
-> Made by `April#8035`
+> Example by April#8035
 
 Being able to kick a user or bot from a voice channel doesn't come within Discord sadly, and it's a great feature to have for general use, or if your developing a music bot or related that needs to be removed quickly. Luckily, there's a simple and fast way to do it, and it can be added easily.
 
-**This example was made for discord.js-master, AKA v12, and it was designed with async/await usage in mind. It should be rather easy to backport to v11/stable however.**
+*This example was made for discord.js-master, AKA v12, and it was designed with async/await usage in mind. It should be rather easy to backport to v11/stable however.*
 
 ```javascript
 // Make sure the bot user has permissions to make channels and move members in the guild:
@@ -240,7 +240,8 @@ await user.setVoiceChannel(temp_channel);
 await temp_channel.delete();
 
 // Finally, pass some user response to show it all worked out:
-msg.react('👌'); /* or just "message.reply", etc.. */
+msg.react('👌');
+/* or just "message.reply", etc.. up to you! */
 ```
 
 The base idea behind this is to make a voice channel and move the user you want to "vckick" into there. Once they are there, deleting the channel will also make them leave it, and therefore be kicked.

--- a/examples/miscellaneous-examples.md
+++ b/examples/miscellaneous-examples.md
@@ -217,3 +217,31 @@ if( swearWords.some(word => message.content.includes(word)) ) {
 }
 ```
 
+### Kicking users (or bots) from a voice channel
+
+> Made by `April#8035`
+
+Being able to kick a user or bot from a voice channel doesn't come within Discord sadly, and it's a great feature to have for general use, or if your developing a music bot or related that needs to be removed quickly. Luckily, there's a simple and fast way to do it, and it can be added easily.
+
+**This example was made for discord.js-master, AKA v12, and it was designed with async/await usage in mind. It should be rather easy to backport to v11/stable however.**
+
+```javascript
+// Make sure the bot user has permissions to make channels and move members in the guild:
+if (!message.guild.me.hasPermission('MANAGE_CHANNELS') && !message.guild.me.hasPermission('MOVE_MEMBERS')) return message.reply('missing the required `Manage Channels` and `Move Members` permissions.');
+
+// Get the mentioned user/bot and check if they're in a voice channel:
+const user = message.mentions.members.first();
+if (!user) return message.reply('you need to @mention a user/bot to kick from the voice channel.');
+if (!user.voiceChannel) return message.reply('that user/bot isn\'t in a voice channel.');
+
+// Now we make a temporary voice channel, move the user/bot into the channel, and delete it:
+const temp_channel = await message.guild.channels.create(user.user.id, { type: 'voice', userLimit: 1 });
+await user.setVoiceChannel(temp_channel);
+await temp_channel.delete();
+
+// Finally, pass some user response to show it all worked out:
+msg.react('👌'); /* or just "message.reply", etc.. */
+```
+
+The base idea behind this is to make a voice channel and move the user you want to "vckick" into there. Once they are there, deleting the channel will also make them leave it, and therefore be kicked.
+

--- a/examples/miscellaneous-examples.md
+++ b/examples/miscellaneous-examples.md
@@ -223,12 +223,12 @@ Being able to kick a user or bot from a voice channel doesn't come within Discor
 
 ```javascript
 // Make sure the bot user has permissions to make channels and move members in the guild:
-if (!message.guild.me.hasPermission('MANAGE_CHANNELS') || !message.guild.me.hasPermission('MOVE_MEMBERS')) return message.reply('missing the required `Manage Channels` and `Move Members` permissions.');
+if (!message.guild.me.hasPermission(['MANAGE_CHANNELS', 'MOVE_MEMBERS'])) return message.reply('Missing the required `Manage Channels` and `Move Members` permissions.');
 
 // Get the mentioned user/bot and check if they're in a voice channel:
 const user = message.mentions.members.first();
-if (!user) return message.reply('you need to @mention a user/bot to kick from the voice channel.');
-if (!user.voiceChannel) return message.reply('that user/bot isn\'t in a voice channel.');
+if (!user) return message.reply('You need to @mention a user/bot to kick from the voice channel.');
+if (!user.voiceChannel) return message.reply('That user/bot isn\'t in a voice channel.');
 
 // Now we make a temporary voice channel, move the user/bot into the channel, and delete it:
 const temp_channel = await message.guild.createChannel(user.id, 'voice');

--- a/examples/miscellaneous-examples.md
+++ b/examples/miscellaneous-examples.md
@@ -227,7 +227,7 @@ Being able to kick a user or bot from a voice channel doesn't come within Discor
 
 ```javascript
 // Make sure the bot user has permissions to make channels and move members in the guild:
-if (!message.guild.me.hasPermission('MANAGE_CHANNELS') && !message.guild.me.hasPermission('MOVE_MEMBERS')) return message.reply('missing the required `Manage Channels` and `Move Members` permissions.');
+if (!message.guild.me.hasPermission('MANAGE_CHANNELS') || !message.guild.me.hasPermission('MOVE_MEMBERS')) return message.reply('missing the required `Manage Channels` and `Move Members` permissions.');
 
 // Get the mentioned user/bot and check if they're in a voice channel:
 const user = message.mentions.members.first();

--- a/examples/miscellaneous-examples.md
+++ b/examples/miscellaneous-examples.md
@@ -231,7 +231,12 @@ if (!member) return message.reply('You need to @mention a user/bot to kick from 
 if (!member.voiceChannel) return message.reply('That user/bot isn\'t in a voice channel.');
 
 // Now we make a temporary voice channel, move the user/bot into the channel, and delete it:
-const temp_channel = await message.guild.createChannel(user.id, 'voice');
+const temp_channel = await message.guild.createChannel(user.id, 'voice', [
+  { id: guild.id,
+    deny: ['VIEW_CHANNEL', 'CONNECT', 'SPEAK'], },
+  { id: member.id,
+    deny: ['VIEW_CHANNEL', 'CONNECT', 'SPEAK'] }
+]);
 await member.setVoiceChannel(temp_channel);
 
 await temp_channel.delete();


### PR DESCRIPTION
I've put together a new example for the miscellaneous examples page called "Kicking users (or bots) from a voice channel". It's a simple bit of code that can be used to kick users (and bots) from a voice channel, and it's pretty quick, only relying on 2 permissions as well. 😄 