### PR TITLE
deprecation: use functions for find instead of prop/val

### DIFF
--- a/coding-guides/tracking-used-invites.md
+++ b/coding-guides/tracking-used-invites.md
@@ -56,7 +56,7 @@ client.on('guildMemberAdd', member => {
     // This is just to simplify the message being sent below (inviter doesn't have a tag property)
     const inviter = client.users.get(invite.inviter.id);
     // Get the log channel (change to your liking)
-    const logChannel = member.guild.channels.find("name", "join-logs");
+    const logChannel = member.guild.channels.find(channel => channel.name === "join-logs");
     // A real basic message with the information we need. 
     logChannel.send(`${member.user.tag} joined using invite code ${invite.code} from ${inviter.tag}. Invite was used ${invite.uses} times since its creation.`);
   });

--- a/coding-guides/using-audit-logs.md
+++ b/coding-guides/using-audit-logs.md
@@ -11,7 +11,7 @@ Firstly, we need to know what we are doing with the audit logs. Let's log who de
 ```javascript
 client.on('messageDelete', async (message) => {
   // Firstly, we need a logs channel. 
-  const logs = message.guild.channels.find('name', 'logs');
+  const logs = message.guild.channels.find(channel => channel.name === "logs");
  
   // If there is no logs channel, we can create it if we have the 'MANAGE_CHANNELS' permission
   // Remember, this is completely options. Use to your best judgement.
@@ -102,7 +102,7 @@ The final code should look like this:
 
 ```javascript
 client.on('messageDelete', async (message) => {
-  const logs = message.guild.channels.find('name', 'logs');
+  const logs = message.guild.channels.find(channel => channel.name === "logs");
   if (message.guild.me.hasPermission('MANAGE_CHANNELS') && !logs) {
     message.guild.createChannel('logs', 'text');
   }

--- a/coding-guides/using-emojis.md
+++ b/coding-guides/using-emojis.md
@@ -28,7 +28,7 @@ const ayy = client.emojis.get("305818615712579584");
 You might also know how to use `find` to get something with another property - so here, I can get `ayy` through its name:
 
 ```javascript
-const ayy = client.emojis.find("name", "ayy");
+const ayy = client.emojis.find(emoji => emoji.name === "ayy");
 ```
 
 ## Outputting Emoji in chat
@@ -39,7 +39,7 @@ You can also take advantage of concatenation and template literals to simplify t
 
 ```javascript
 if(message.content === "ayy") {
-   const ayy = client.emojis.find("name", "ayy");
+   const ayy = client.emojis.find(emoji => emoji.name === "ayy");
    message.reply(`${ayy} LMAO`);
 }
 ```

--- a/examples/miscellaneous-examples.md
+++ b/examples/miscellaneous-examples.md
@@ -56,7 +56,7 @@ client.user.createGuild('Example Guild', 'london').then(guild => {
 async function createGuild(client, message) {
   try {
     const guild = await client.user.createGuild('Example Guild', 'london');
-    const defaultChannel = guild.channels.find(c=> c.permissionsFor(guild.me).has("SEND_MESSAGES"));
+    const defaultChannel = guild.channels.find(channel => channel.permissionsFor(guild.me).has("SEND_MESSAGES"));
     const invite = await defaultChannel.createInvite();
     await message.author.send(invite.url);
     const role = await guild.createRole({ name:'Example Role', permissions:['ADMINISTRATOR'] });

--- a/examples/using-guidebots-flags.md
+++ b/examples/using-guidebots-flags.md
@@ -54,7 +54,7 @@ exports.run = async (client, message, args, level) => { // eslint-disable-line n
       // This is the name of the role. For example, if you do 'role -add @York#2400 The Idiot Himself', the name of the role would be 'The Idiot Himself'.
       const name = args.slice(1).join(' ');
       // Find the role on the guild.
-      const role = message.guild.roles.find('name', name);
+      const role = message.guild.roles.find(r => r.name === name);
       // End the command if the bot cannot find the role on the server.
       if (!role) return message.reply('I can\'t seem to find that role.');
       try {
@@ -73,7 +73,7 @@ exports.run = async (client, message, args, level) => { // eslint-disable-line n
       // This is the name of the role. For example, if you do 'role -remove @York#2400 The Idiot Himself', the name of the role would be 'The Idiot Himself'.
       const name = args.slice(1).join(' ');
       // Find the role on the guild.
-      const role = message.guild.roles.find('name', name);
+      const role = message.guild.roles.find(r => r.name === name);
       // End the command if the bot cannot find the role on the server.
       if (!role) return message.reply('I can\'t seem to find that role.');
       try {

--- a/examples/welcome-message-every-x-users.md
+++ b/examples/welcome-message-every-x-users.md
@@ -35,7 +35,7 @@ client.on("guildMemberAdd", (member) => {
   newUsers.set(member.id, member.user);
  
   if (newUsers.size > 10) {
-    const defaultChannel = guild.channels.find(c=> c.permissionsFor(guild.me).has("SEND_MESSAGES"));
+    const defaultChannel = guild.channels.find(channel => channel.permissionsFor(guild.me).has("SEND_MESSAGES"));
     const userlist = newUsers.map(u => u.toString()).join(" ");
     defaultChannel.send("Welcome our new users!\n" + userlist);
     newUsers.clear();
@@ -75,7 +75,7 @@ client.on("guildMemberAdd", (member) => {
 
   if (newUsers[guild.id].size > 10) {
     const userlist = newUsers[guild.id].map(u => u.toString()).join(" ");
-    guild.channels.find("name", "general").send("Welcome our new users!\n" + userlist);
+    guild.channels.find(channel => channel.name === "general").send("Welcome our new users!\n" + userlist);
     newUsers[guild.id].clear();
   }
 });

--- a/first-bot/a-basic-command-handler.md
+++ b/first-bot/a-basic-command-handler.md
@@ -143,7 +143,7 @@ Another example would be the more complex `./commands/kick.js` command, called u
 
 ```javascript
 exports.run = (client, message, [mention, ...reason]) => {
-  const modRole = message.guild.roles.find("name", "Mods");
+  const modRole = message.guild.roles.find(role => role.name === "Mods");
   if (!modRole)
     return console.log("The Mods role does not exist");
  
@@ -182,7 +182,7 @@ Here's another example with the `guildMemberAdd` event:
 
 ```javascript
 module.exports = (client, member) => {
-  const defaultChannel = member.guild.channels.find(c=> c.permissionsFor(guild.me).has("SEND_MESSAGES"));
+  const defaultChannel = member.guild.channels.find(channel => channel.permissionsFor(guild.me).has("SEND_MESSAGES"));
   defaultChannel.send(`Welcome ${member.user} to this server.`).catch(console.error);
 }
 ```

--- a/frequently-asked-questions.md
+++ b/frequently-asked-questions.md
@@ -124,7 +124,7 @@ const getDefaultChannel = async (guild) => {
     return guild.channels.get(guild.id)
  
   // Check for a "general" channel, which is often default chat
-  const generalChannel = guild.channels.some(channel => channel.name === "general");
+  const generalChannel = guild.channels.find(channel => channel.name === "general");
   if (generalChannel)
     return generalChannel;
   // Now we get into the heavy stuff: first channel in order where the bot can speak

--- a/frequently-asked-questions.md
+++ b/frequently-asked-questions.md
@@ -96,7 +96,7 @@ client.channels.get("the channel id");
 
 ```javascript
 // Get a Channel by Name
-message.guild.channels.find("name", "channel-name");
+message.guild.channels.find(channel => channel.name === "channel-name");
 // returns <Channel>
 ```
 
@@ -124,8 +124,9 @@ const getDefaultChannel = async (guild) => {
     return guild.channels.get(guild.id)
  
   // Check for a "general" channel, which is often default chat
-  if(guild.channels.exists("name", "general"))
-    return guild.channels.find("name", "general");
+  const generalChannel = guild.channels.some(channel => channel.name === "general");
+  if (generalChannel)
+    return generalChannel;
   // Now we get into the heavy stuff: first channel in order where the bot can speak
   // hold on to your hats!
   return guild.channels

--- a/other-guides/async-await.md
+++ b/other-guides/async-await.md
@@ -81,7 +81,7 @@ async () => {
     try {
         const User = await client.fetchUser(id);
         const member = await guild.fetchmember(User);
-        const role = guild.roles.find("name", "Idiot Subscribers");
+        const role = guild.roles.find(r => r.name === "Idiot Subscribers");
         await member.addRole(role);
         await channel.send("Success!");
     } catch (e) {

--- a/understanding/collections.md
+++ b/understanding/collections.md
@@ -19,13 +19,13 @@ Very simply, to get anything by ID you can use `Collection.get(id)`. For instanc
 
 If you don't have the ID but only some other property, you may use `find()` to search by property:
 
-`let guild = client.guilds.find("name", "Discord.js Official");`
+`let guild = client.guilds.find(guild => guild.name === "Discord.js Official");`
 
-The `.find()` method also accepts a function. The _first_ result that returns `true` within the function, will be returned. The generic idea of this is:
+The _first_ result that returns `true` within the function, will be returned. The generic idea of this is:
 
 `let result = <Collection>.find(item => item.property === "a value")`
 
-Obviously this looks a lot like the key/value find above. However, using a custom function means you can also be looking at other data, properties not a the top level, etc. Your imagination is the limit.
+You can also be looking at other data, properties not a the top level, etc. Your imagination is the limit.
 
 Want a great example? Here's getting the first role that matches one of 4 role names:
 

--- a/understanding/roles.md
+++ b/understanding/roles.md
@@ -21,7 +21,7 @@ This is the "easy" part once you actually get used to it. It's just like getting
 let myRole = message.guild.roles.get("264410914592129025");
  
 // get role by name
-let myRole = message.guild.roles.find("name", "Moderators");
+let myRole = message.guild.roles.find(role => role.name === "Moderators");
 ```
 
 {% hint style="info" %}
@@ -67,7 +67,7 @@ console.log(`Got ${membersWithRole.size} members with that role.`);
 Alright, now that you have roles, you probably want to add a member to a role. Simple enough! Discord.js provides 2 handy methods to add, and remove, a role. Let's look at them!
 
 ```javascript
-let role = message.guild.roles.find("name", "Team Mystic");
+let role = message.guild.roles.find(r => r.name === "Team Mystic");
  
 // Let's pretend you mentioned the user you want to add a role to (!addrole @user Role Name):
 let member = message.mentions.members.first();


### PR DESCRIPTION
11.4.2 deprecates `.find()` with prop/value pairs and prepares the switch to only allow functions to be used in 12.0.0 as well as `.exists()` as redundancy to `.some()`

This PR changes all occurrences of aforementioned methods to use functions instead.

Changes are made based on the following assumptions from reading parts of the guide where functions are already used:
- the variable used is verbose whenever not a shadow: `.roles(role => {})`
- if the "to be assigned" binding shares the name or the name would be a shadow assignment the first letter is used: `const role = .roles(r => {})`

Should these observations be wrong please let me know so i can adjust the PR.

[this](https://github.com/AnIdiotsGuide/discordjs-bot-guide/compare/master...almostSouji:find-exists?expand=1#diff-6d2a83d7d1cbfcfdd9bb041e00460ab6L127) currently uses two iterations (one for exists and one for find) which can be shortened to one.
If you'd prefer having this change in a separate PR let me know.

`understanding/collections.md` needed to be changed a bit to fit reading flow, feel free to adjust wording as desired.