### PR TITLE
Update to "SQLite-Based Points System"

### DIFF
--- a/coding-guides/sqlite-based-points-system.md
+++ b/coding-guides/sqlite-based-points-system.md
@@ -11,7 +11,7 @@ This guide was updated on 2018/03/16 to use `better-sqlite3` which, believe it o
 ## Installation
 
 {% hint style="warning" %}
-**Pre-Requisites**: `better-sqlite3`, similarly to a lot of modules, gets compiled using `node-gyp` which has 2 very important requirements: Python 2.7 and the C++ Build Tools. For windows, open up an Elevated \(Administrator\) command prompt and run the following FIRST, before installing better-sqlite3: `npm i -g --production windows-build-tools`. For linux, you need `sudo apt-get install build-essential` and you need to figure out how to install Python 2.7 \(NOT Python 3!\) on your system.
+**Pre-Requisites**: `better-sqlite3`, similarly to a lot of modules, gets compiled using `node-gyp` which has 2 very important requirements: Python 2.7 and the C++ Build Tools. For windows, open up an Elevated \(Administrator\) command prompt and run the following FIRST, before installing better-sqlite3: `npm i --vs2015 -g windows-build-tools`. For linux, you need `sudo apt-get install build-essential` and you need to figure out how to install Python 2.7 \(NOT Python 3!\) on your system.
 {% endhint %}
 
 For this guide to work, you first need to make sure you have the proper modules installed. Let's assume you already have `discord.js` installed, and go straight to installing the sqlite one and its node-gyp dependency:


### PR DESCRIPTION
"npm i -g --production windows-build-tools" did not work on two different Windows PCs, but "npm i --vs2015 -g windows-build-tools" works perfectly. Apparently I'm not the only one who has this issue, credit to this post for figuring it out: https://github.com/nodejs/node-gyp/issues/1486#issuecomment-451719871