### PR TITLE
Update miscellaneous-examples.md

### DIFF
--- a/examples/miscellaneous-examples.md
+++ b/examples/miscellaneous-examples.md
@@ -194,7 +194,7 @@ Support for kicking members from voice channels has now been added by Discord an
 
 ```javascript
 // Make sure the bot user has permissions to move members in the guild:
-if (!message.guild.me.hasPermission(['MANAGE_CHANNELS', 'MOVE_MEMBERS'])) return message.reply('Missing the required `Move Members` permission.');
+if (!message.guild.me.hasPermission('MOVE_MEMBERS')) return message.reply('Missing the required `Move Members` permission.');
 
 // Get the mentioned user/bot and check if they're in a voice channel:
 const member = message.mentions.members.first();


### PR DESCRIPTION
Removes a check for MANAGE_CHANNELS from the voice channel kick example. As of #71, we're no longer creating a new voice channel, so this permission check is redundant.