### PR TITLE
Quotes In console.log('client.guilds.size'); on sharding page

### DIFF
--- a/understanding/sharding.md
+++ b/understanding/sharding.md
@@ -70,7 +70,7 @@ Example:
 
 // If we just get our client.guilds.size, it will return
 // only the number of guilds on the shard this is being run on.
-console.log('client.guilds.size');
+console.log(client.guilds.size);
 // 1050
 
 // If we would like to get our client.guilds.size from all


### PR DESCRIPTION
This would log `client.guilds.size`, not a `Number` with the value. This seems to be a typo, because well
### doesn't using quotes in `console.log` log the `String`, not the `Number`...