### PR TITLE
fix(sharding): call spawn after attaching listener

### DIFF
--- a/understanding/sharding.md
+++ b/understanding/sharding.md
@@ -69,11 +69,11 @@ const manager = new ShardingManager('./YOUR_BOT_FILE_NAME.js', {
     token: 'YOUR_TOKEN_GOES_HERE'
 });
 
-// Spawn your shards
-manager.spawn();
-
 // Emitted when a shard is created
 manager.on('shardCreate', (shard) => console.log(`Shard ${shard.id} launched`));
+
+// Spawn your shards
+manager.spawn();
 ```
 
 ## Sharing Information Between Shards


### PR DESCRIPTION
This is to prevent a race condition possibly preventing shard 0 from logging the successful launch