### PR TITLE
Fixing ReferenceError in catch block

### DIFF
--- a/examples/making-an-eval-command.md
+++ b/examples/making-an-eval-command.md
@@ -109,7 +109,7 @@ client.on("messageCreate", async (message) => {
       message.channel.send(`\`\`\`js\n${cleaned}\n\`\`\``);
     } catch (err) {
       // Reply in the channel with our error
-      message.channel.send(`\`ERROR\` \`\`\`xl\n${cleaned}\n\`\`\``);
+      message.channel.send(`\`ERROR\` \`\`\`xl\n${err.stack}\n\`\`\``);
     }
 
     // End of our command


### PR DESCRIPTION
Sending error to channel results in a ReferenceError because cleaned is not defined in the catch block's scope.

Replaced with sending the error's stack to resolve this.