### PR TITLE
Fixed "err" confused with "cleaned"

### DIFF
--- a/examples/making-an-eval-command.md
+++ b/examples/making-an-eval-command.md
@@ -109,7 +109,7 @@ client.on("messageCreate", async (message) => {
       message.channel.send(`\`\`\`js\n${cleaned}\n\`\`\``);
     } catch (err) {
       // Reply in the channel with our error
-      message.channel.send(`\`ERROR\` \`\`\`xl\n${cleaned}\n\`\`\``);
+      message.channel.send(`\`ERROR\` \`\`\`xl\n${err}\n\`\`\``);
     }
 
     // End of our command


### PR DESCRIPTION
In the error message of the eval command, the content used a `cleaned` variable that only exists on the `try` block, not on the `catch` block, the `err` variable should've been used instead